### PR TITLE
Locking simplepie down to ~v1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	"require": {
 		"php": ">=5.3.2",
 		"symfony/framework-bundle": "~2.0",
-		"simplepie/simplepie": "*"
+		"simplepie/simplepie": "~1.3"
 	},
 	"autoload": {
 		"psr-0": { "Fkr\\SimplePieBundle": "" }


### PR DESCRIPTION
- Locking simplepie dep down to ~v1.3 to avoid pulling in breaking changes.
