### PR TITLE
Fix deprecated usages for SF 2.6 and upgrade compatibility for SF 3.0

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -13,7 +13,8 @@
     </parameters>
 
     <services>
-        <service id="fkr_simple_pie.rss" class="SimplePie" factory-class="%fkr_simple_pie.factory%" factory-method="create">
+        <service id="fkr_simple_pie.rss" class="SimplePie">
+            <factory class="%fkr_simple_pie.factory%" method="create" />
 			<argument>%fkr_simple_pie.cache_enabled%</argument>
 			<argument>%fkr_simple_pie.cache_dir%</argument>
 			<argument>%fkr_simple_pie.cache_duration%</argument>

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	],
 	"require": {
 		"php": ">=5.3.2",
-		"symfony/framework-bundle": "~2.0",
+		"symfony/framework-bundle": "~2.6|~3.0",
 		"simplepie/simplepie": "~1.3"
 	},
 	"autoload": {


### PR DESCRIPTION
Hello,

I'm cleaning a project of all the deprecated uses for SF 2.8.
This project use the FkrSimplePieBundle that I have cleaned as well.